### PR TITLE
Add link to repository in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["J/A <archer884@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/archer884/syllable"
 keywords = ["english", "flesch-kincaid", "readability", "syllable", "word-count"]
 categories = ["text-processing"]
 description = """


### PR DESCRIPTION
This way there will be a link to the repo from crates.io and from the documentation, which is just convenient.